### PR TITLE
only query keytar if the connection has a password

### DIFF
--- a/src/commands/addConnection.ts
+++ b/src/commands/addConnection.ts
@@ -47,6 +47,7 @@ export class addConnectionCommand extends BaseCommand {
     connections[id] = { label, host, user, port: nPort, certPath, database };
 
     if (password) {
+      connections[id].password = "<password>";
       await Global.keytar.setPassword(Constants.ExtensionId, id, password);
     }
 

--- a/src/commands/renameConnection.ts
+++ b/src/commands/renameConnection.ts
@@ -22,7 +22,7 @@ export class renameConnectionCommand extends BaseCommand {
 
     if (treeNode && treeNode.connection) {
       selectedConnection = Object.assign({}, treeNode.connection);
-      delete selectedConnection.password;
+      selectedConnection.password = selectedConnection.password ? "<password>" : null;
       selectedConnId = treeNode.id;
     } else {
       let hosts: ConnectionQuickPickItem[] = [];

--- a/src/commands/selectConnection.ts
+++ b/src/commands/selectConnection.ts
@@ -42,7 +42,9 @@ export class selectConnectionCommand extends BaseCommand {
 
     if (!hostToSelect.is_new_selector) {
       let connection: IConnection = Object.assign({}, connections[hostToSelect.connection_key]);
-      connection.password = await Global.keytar.getPassword(Constants.ExtensionId, hostToSelect.connection_key);
+      if (connection.password == "<password>") {
+        connection.password = await Global.keytar.getPassword(Constants.ExtensionId, hostToSelect.connection_key);
+      }
       EditorState.connection = connection;
       await vscode.commands.executeCommand('vscode-postgres.selectDatabase');
       return;

--- a/src/common/configFileSystem.ts
+++ b/src/common/configFileSystem.ts
@@ -119,7 +119,9 @@ export class ConfigFS implements vscode.FileSystemProvider {
     if (connections && connections.hasOwnProperty(connectionKey)) {
       // create the file
       let connection: IConnection = Object.assign({}, connections[connectionKey]);
-      connection.password = await Global.keytar.getPassword(Constants.ExtensionId, connectionKey);
+      if (connection.password == "<password>") {
+        connection.password = await Global.keytar.getPassword(Constants.ExtensionId, connectionKey);
+      }
       let connString = JSON.stringify(connection, null, 2);
       configFile = new ConfigFile(connection.label || connection.host);
       configFile.data = Buffer.from(connString);

--- a/src/common/configFileSystem.ts
+++ b/src/common/configFileSystem.ts
@@ -86,13 +86,15 @@ export class ConfigFS implements vscode.FileSystemProvider {
       throw vscode.FileSystemError.NoPermissions(`Missing "password" key`);
         
     let pwd = newDetails.password;
-    delete newDetails.password;
+    newDetails.password = newDetails.password ? "<password>" : null;
     let connection: IConnection = Object.assign({}, newDetails);
 
     connections[connectionKey] = connection;
     const tree = PostgreSQLTreeDataProvider.getInstance();
 
-    await Global.keytar.setPassword(Constants.ExtensionId, connectionKey, pwd);
+    if (pwd) {
+      await pwd.keytar.setPassword(Constants.ExtensionId, connectionKey, pwd);
+    }
     await Global.context.globalState.update(Constants.GlobalStateKey, connections)
     tree.refresh();
     this._fireSoon({type: vscode.FileChangeType.Changed, uri});

--- a/src/tree/treeProvider.ts
+++ b/src/tree/treeProvider.ts
@@ -61,9 +61,10 @@ export class PostgreSQLTreeDataProvider implements vscode.TreeDataProvider<INode
     const ConnectionNodes = [];
     if (connections) {
       for (const id of Object.keys(connections)) {
-        const password = await Global.keytar.getPassword(Constants.ExtensionId, id);
         let connection: IConnection = Object.assign({}, connections[id]);
-        connection.password = password;
+        if (connection.password == "<password>") {
+          connection.password = await Global.keytar.getPassword(Constants.ExtensionId, id);
+        }
         ConnectionNodes.push(new ConnectionNode(id, connection));
       }
     }


### PR DESCRIPTION
I'm connecting without a password with my user and ran in the same problem as #38.

`keytar` is queried for every connection even when there was no password set.
So this PR removes the need for a working `keytar` service when no password is set without storing plain passwords.