### PR TITLE
Introduce a config option to control statusbar usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ This extension contributes the following settings:
 
 * `vscode-postgres.showExplorer`: enable/disable the database explorer.
 * `vscode-postgres.prettyPrintJSONfields`: set to `true` to enable nicely formatted JSON in the query results window.
+* `vscode-postgres.useStatusBar`: set to `false` to disable usage of the status bar for managing the query connection.
 * `vscode-postgres.setConnectionFromExplorer`: set to `ifunset` to only set the query connection if not already set.
 * `vscode-postgres.tableColumnSortOrder`: set to `db-order` to sort columns like the database does, `alpha` to sort alphabetically, and `reverse-alpha` for descending alphabetically.
 * `vscode-postgres.intervalFormat`: set to `iso_8601` to format intervals according to the ISO 8601 standard, `humanize` to format as easy to read text, and `succinct` to format like a countdown clock.

--- a/package.json
+++ b/package.json
@@ -58,6 +58,11 @@
           "default": false,
           "description": "Turns on/off pretty printing of JSON fields"
         },
+        "vscode-postgres.useStatusBar": {
+          "type": "boolean",
+          "default": true,
+          "description": "Turns on/off usage of status bar for managing connection"
+        },
         "vscode-postgres.setConnectionFromExplorer": {
           "type": "string",
           "enum": [

--- a/src/common/editorState.ts
+++ b/src/common/editorState.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import { IConnection } from './IConnection';
 import PostgreSQLLanguageClient from '../language/client';
+import { Global } from './global';
 
 export class EditorState {
 
@@ -49,6 +50,19 @@ export class EditorState {
   onDidChangeActiveTextEditor(e: vscode.TextEditor) {
     let conn: IConnection = e && e.document && e.document.uri ? this.metadata.get(e.document.uri.toString()) : null;
     this.languageClient.setConnection(conn);
+
+    if (!Global.Configuration.get<boolean>("useStatusBar")) {
+      if (this.statusBarServer) {
+        this.statusBarServer.hide();
+      }
+
+      if (this.statusBarDatabase) {
+        this.statusBarDatabase.hide();
+      }
+
+      return;
+    }
+
     if (conn) {
       // set the status buttons
       this.setStatusButtons(conn);


### PR DESCRIPTION
Introduces a config option `useStatusBar` that defaults to the current behavior of adding dropdowns to the status bar to control the query connection, but if set to false, results in no extra space being taken up in the status bar (use the explorer to select the database in this case). 