### PR TITLE
Hide all pg_temp and pg_toast_temp schemas

### DIFF
--- a/src/language/server.ts
+++ b/src/language/server.ts
@@ -179,7 +179,9 @@ async function loadCompletionCache(connectionOptions: IDBConnection) {
             FROM
               pg_tables
             WHERE
-              schemaname not in ('information_schema', 'pg_catalog', 'pg_toast', 'pg_temp_1', 'pg_toast_temp_1')
+              schemaname not in ('information_schema', 'pg_catalog', 'pg_toast')
+              AND schemaname not like 'pg_temp_%'
+              AND schemaname not like 'pg_toast_temp_%'
               AND has_schema_privilege(quote_ident(schemaname), 'CREATE, USAGE') = true
               AND has_table_privilege(quote_ident(schemaname) || '.' || quote_ident(tablename), 'SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER') = true
             union all
@@ -190,7 +192,9 @@ async function loadCompletionCache(connectionOptions: IDBConnection) {
               false as is_table
             FROM pg_views
             WHERE
-              schemaname not in ('information_schema', 'pg_catalog', 'pg_toast', 'pg_temp_1', 'pg_toast_temp_1')
+              schemaname not in ('information_schema', 'pg_catalog', 'pg_toast')
+              AND schemaname not like 'pg_temp_%'
+              AND schemaname not like 'pg_toast_temp_%'
               AND has_schema_privilege(quote_ident(schemaname), 'CREATE, USAGE') = true
               AND has_table_privilege(quote_ident(schemaname) || '.' || quote_ident(viewname), 'SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER') = true
           ) as tbl

--- a/src/tree/databaseNode.ts
+++ b/src/tree/databaseNode.ts
@@ -36,7 +36,9 @@ export class DatabaseNode implements INode {
       SELECT nspname as name
       FROM pg_namespace
       WHERE
-        nspname not in ('information_schema', 'pg_catalog', 'pg_toast', 'pg_temp_1', 'pg_toast_temp_1')
+        nspname not in ('information_schema', 'pg_catalog', 'pg_toast')
+        AND nspname not like 'pg_temp_%'
+        AND nspname not like 'pg_toast_temp_%'
         AND has_schema_privilege(oid, 'CREATE, USAGE')
       ORDER BY nspname;`);
 


### PR DESCRIPTION
When using temporary tables a lot of `pg_temp_X` and `pg_toast_temp_X` will be created and for performance reasons left laying around. All schemas starting with such prefixes should be ignored