### PR TITLE
fix error: column p.proisagg does not exist on postgres 11

### DIFF
--- a/src/common/global.ts
+++ b/src/common/global.ts
@@ -10,6 +10,10 @@ export class Global {
   public static context: vscode.ExtensionContext = null;
   public static ResultManager: ResultsManager = null;
 
+  // Postgres 11 uses prokind, in pg_proc, instead of proisagg and proiswindow
+  // Determines current postgres version on Database.createConnection and stores the suitable query string
+  public static prokind: string = "";
+
   public static get Configuration(): vscode.WorkspaceConfiguration {
     return vscode.workspace.getConfiguration(Constants.ExtensionId);
   }

--- a/src/tree/funcFolderNode.ts
+++ b/src/tree/funcFolderNode.ts
@@ -5,6 +5,7 @@ import { TreeItem, TreeItemCollapsibleState } from "vscode";
 import { Database } from "../common/database";
 import { FunctionNode } from "./functionNode";
 import { InfoNode } from "./infoNode";
+import { Global } from '../common/global';
 
 export class FunctionFolderNode implements INode {
   constructor(public readonly connection: IConnection
@@ -34,8 +35,7 @@ export class FunctionFolderNode implements INode {
         pg_catalog.pg_get_function_result(p.oid) as "result_type",
         pg_catalog.pg_get_function_arguments(p.oid) as "argument_types",
       CASE
-        WHEN p.proisagg THEN 'agg'
-        WHEN p.proiswindow THEN 'window'
+        ${Global.prokind}
         WHEN p.prorettype = 'pg_catalog.trigger'::pg_catalog.regtype THEN 'trigger'
         ELSE 'normal'
       END as "type"


### PR DESCRIPTION
This is an PR on issue #72 

Here is my "temporary" solution.
1. Postgres version determined when a new database client connection is up
    - Referenced to this [commit](https://github.com/jOOQ/jOOQ/commit/824e74ba9c83dfa905918308450718fdf6958e47)
2. Stores the corresponding query string to a new global var: `prokind`
3. In `FunctionFolderNode`, `prokind` is interpolated into query string

I've also tested the older version of Postgres, but not sure if there's another better approach.