### PR TITLE
add condition to display runQuery.

### DIFF
--- a/package.json
+++ b/package.json
@@ -197,7 +197,7 @@
         },
         {
           "command": "vscode-postgres.runQuery",
-          "when": "editorLangId != postgres && editorHasSelection && !editorHasMultipleSelections"
+          "when": "editorLangId != postgres && config.vscode-postgres.defaultConnection != '' && config.vscode-postgres.defaultDatabase != '' && editorHasSelection && !editorHasMultipleSelections"
         },
         {
           "command": "vscode-postgres.selectTop",
@@ -215,7 +215,7 @@
       "editor/context": [
         {
           "command": "vscode-postgres.runQuery",
-          "when": "editorLangId != postgres && editorHasSelection && !editorHasMultipleSelections",
+          "when": "editorLangId != postgres && config.vscode-postgres.defaultConnection != '' && config.vscode-postgres.defaultDatabase != '' && editorHasSelection && !editorHasMultipleSelections",
           "group": "navigation"
         },
         {


### PR DESCRIPTION
I usually run the query by clicking on the table without selecting the default database.

When don't select a default database, I get "Run Query" command in the context menu even though I can't run it.
So I have modified condition to display "Run Query".