### PR TITLE
ignore tables without any columns

### DIFF
--- a/src/language/server.ts
+++ b/src/language/server.ts
@@ -226,7 +226,7 @@ async function loadCompletionCache(connectionOptions: IDBConnection) {
               AND n.nspname not in ('information_schema', 'pg_catalog', 'pg_toast')
               AND n.nspname not like 'pg_temp_%'
               AND n.nspname not like 'pg_toast_temp_%'
-              AND n.nspname not like '\_timescaledb\_%'
+              AND c.relnatts > 0
               AND has_schema_privilege(n.oid, 'USAGE') = true
               AND has_table_privilege(quote_ident(n.nspname) || '.' || quote_ident(c.relname), 'SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER') = true
             union all

--- a/src/language/server.ts
+++ b/src/language/server.ts
@@ -226,6 +226,7 @@ async function loadCompletionCache(connectionOptions: IDBConnection) {
               AND n.nspname not in ('information_schema', 'pg_catalog', 'pg_toast')
               AND n.nspname not like 'pg_temp_%'
               AND n.nspname not like 'pg_toast_temp_%'
+              AND n.nspname not like '\_timescaledb\_%'
               AND has_schema_privilege(n.oid, 'USAGE') = true
               AND has_table_privilege(quote_ident(n.nspname) || '.' || quote_ident(c.relname), 'SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER') = true
             union all


### PR DESCRIPTION
Fixes #103

I'm not a typescript coder, but this solves the terminal popping up incessantly when writing queries to a timescaled database (which will have tables without columns)

The better way to solve this would be to ignore those tables altogether, I'm filtering `_timescaledb_*` tables, but probably counting the columns would be a more general case.